### PR TITLE
Finished create post logic implementation

### DIFF
--- a/app/api/prompt/new/route.js
+++ b/app/api/prompt/new/route.js
@@ -1,0 +1,22 @@
+import { connectToDB } from "@utils/database";
+// prompt route
+import Prompt from "@models/prompt";
+
+export const POST = async (req, res) => {
+  const { userId, prompt, tag } = await req.json();
+
+  try {
+    await connectToDB();
+    const newPrompt = new Prompt({
+      creator: userId,
+      prompt,
+      tag
+    })
+
+    await newPrompt.save();
+
+    return new Response(JSON.stringify(newPrompt), { status: 201 });
+  } catch (error) {
+    return new Response("Failed to create a new prompt", { status: 500 });
+  }
+}

--- a/app/create-prompt/page.jsx
+++ b/app/create-prompt/page.jsx
@@ -7,13 +7,38 @@ import { useRouter } from "next/navigation";
 import Form from "@components/Form";
 
 const CreatePrompt = () => {
+  const router = useRouter();
+  const { data: session } = useSession();
+
   const [submiting, setSubmiting] = useState(false);
   const [post, setPost] = useState({
     prompt: "",
     tag: "",
   });
 
-  const createPrompt = async (e) => {};
+  const createPrompt = async (e) => {
+    e.preventDefault();
+    setSubmiting(true);
+
+    try {
+      const response = await fetch("api/prompt/new", {
+        method: "POST",
+        body: JSON.stringify({
+          prompt: post.prompt,
+          userId: session?.user.id,
+          tag: post.tag,
+        }),
+      });
+
+      if (response.ok) {
+        router.push("/");
+      }
+    } catch (error) {
+      console.log(error);
+    } finally {
+      setSubmiting(false);
+    }
+  };
 
   return (
     <Form

--- a/models/prompt.js
+++ b/models/prompt.js
@@ -1,0 +1,20 @@
+import { Schema, model, models } from "mongoose";
+
+const PromptSchema = new Schema({
+  creator: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+  },
+  prompt: {
+    type: String,
+    required: [true, 'Prompt is required!']
+  },
+  tag: {
+    type: String,
+    required: [true, 'Tag is required!']
+  }
+});
+
+const Prompt = models.Prompt || model('Prompt', PromptSchema);
+
+export default Prompt;


### PR DESCRIPTION
- created `route.js` file where we made a **POST** `async` function for saving _User_ prompt to the _MongoDb_
- used `{ connectToDb }` function from `'@utils'` 
- created a new `page.jsx` in 'create-prompt' folder
- inside of `page.jsx` created `createPrompt()` function with `try/catch` block, where we fetched data from our _api_ route ( '`api/prompt/new`' )
- created `PromptSchema` model for our input fields from previously created `<Form />` component